### PR TITLE
Unify builder methods and renaming traits

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ BinaryPred  :=  EQ | NEQ | GT | LT | GEQ | LEQ | IN | LIKE ...
 Where:
 
 - `Criteria` is the main expression of the DSL
-- `ConjOp` is the conjunction operator expression
+- `Conjuction` is the conjunction operator expression
 - `UnaryPredOp` is the unary predicate operator expression
 - `BinaryPredOp` is the binary predicate operator expression
 - `Ref` is a reference to a value or a column
@@ -52,14 +52,14 @@ libraryDependencies += "io.github.rafafrdz" %% "criteria4s-sql" % "<version>" //
 <dependency>
     <groupId>io.github.rafafrdz</groupId>
     <artifactId>criteria4s-core_2.13</artifactId>
-    <version>0.7.0</version>
+    <version>0.8.0</version>
 </dependency>
 
 <!-- SQL implementation -->
 <dependency>
     <groupId>io.github.rafafrdz</groupId>
     <artifactId>criteria4s-core_2.13</artifactId>
-    <version>0.7.0</version>
+    <version>0.8.0</version>
 </dependency>
 ```
 

--- a/core/src/main/scala/io/github/rafafrdz/criteria4s/core/Conjuction.scala
+++ b/core/src/main/scala/io/github/rafafrdz/criteria4s/core/Conjuction.scala
@@ -1,28 +1,29 @@
 package io.github.rafafrdz.criteria4s.core
 
 import io.github.rafafrdz.criteria4s.core.Criteria._
-import io.github.rafafrdz.criteria4s.instances.builder.Builder2
+import io.github.rafafrdz.criteria4s.instances.builder.BuilderBinary
 
-trait ConjOp[T <: CriteriaTag] {
+trait Conjuction[T <: CriteriaTag] {
   def eval(cr1: Criteria[T], cr2: Criteria[T]): Criteria[T]
 }
 
-object ConjOp {
+object Conjuction {
+
   def eval[T <: CriteriaTag](cr1: Criteria[T], cr2: Criteria[T])(implicit
-      ev: ConjOp[T]
+      ev: Conjuction[T]
   ): Criteria[T] =
     ev.eval(cr1, cr2)
 
-  trait OR[T <: CriteriaTag] extends ConjOp[T]
+  trait OR[T <: CriteriaTag] extends Conjuction[T]
 
-  trait AND[T <: CriteriaTag] extends ConjOp[T]
+  trait AND[T <: CriteriaTag] extends Conjuction[T]
 
-  implicit val orBuilder: Builder2[OR] = new Builder2[OR] {
+  implicit val orBuilder: BuilderBinary[OR] = new BuilderBinary[OR] {
     override def build[T <: CriteriaTag](F: (String, String) => String): OR[T] =
       (cr1: Criteria[T], cr2: Criteria[T]) => pure(F(cr1.value, cr2.value))
   }
 
-  implicit val andBuilder: Builder2[AND] = new Builder2[AND] {
+  implicit val andBuilder: BuilderBinary[AND] = new BuilderBinary[AND] {
     override def build[T <: CriteriaTag](F: (String, String) => String): AND[T] =
       (cr1: Criteria[T], cr2: Criteria[T]) => pure(F(cr1.value, cr2.value))
   }

--- a/core/src/main/scala/io/github/rafafrdz/criteria4s/core/Criteria.scala
+++ b/core/src/main/scala/io/github/rafafrdz/criteria4s/core/Criteria.scala
@@ -12,5 +12,5 @@ object Criteria {
 
     override def value: String = v
   }
-  trait CriteriaTag
+  private [core] trait CriteriaTag
 }

--- a/core/src/main/scala/io/github/rafafrdz/criteria4s/core/Predicate.scala
+++ b/core/src/main/scala/io/github/rafafrdz/criteria4s/core/Predicate.scala
@@ -1,7 +1,7 @@
 package io.github.rafafrdz.criteria4s.core
 
 import io.github.rafafrdz.criteria4s.core.Criteria._
-import io.github.rafafrdz.criteria4s.instances.builder.{Builder1, Builder2}
+import io.github.rafafrdz.criteria4s.instances.builder.{BuilderUnary, BuilderBinary}
 
 sealed trait Predicate[T <: CriteriaTag]
 
@@ -21,7 +21,7 @@ object PredicateUnary {
 
   trait ISNOTNULL[T <: CriteriaTag] extends PredicateUnary[T]
 
-  implicit val isNullBuilder: Builder1[ISNULL] = new Builder1[ISNULL] {
+  implicit val isNullBuilder: BuilderUnary[ISNULL] = new BuilderUnary[ISNULL] {
     override def build[T <: CriteriaTag](F: String => String): ISNULL[T] = new ISNULL[T] {
       override def eval[V](ref: Ref[T, V])(implicit show: Show[V, T]): Criteria[T] = pure(
         F(ref.asString)
@@ -29,7 +29,7 @@ object PredicateUnary {
     }
   }
 
-  implicit val isNotNullBuilder: Builder1[ISNOTNULL] = new Builder1[ISNOTNULL] {
+  implicit val isNotNullBuilder: BuilderUnary[ISNOTNULL] = new BuilderUnary[ISNOTNULL] {
     override def build[T <: CriteriaTag](F: String => String): ISNOTNULL[T] = new ISNOTNULL[T] {
       override def eval[V](ref: Ref[T, V])(implicit show: Show[V, T]): Criteria[T] = pure(
         F(ref.asString)
@@ -62,7 +62,7 @@ object PredicateBinary {
 
   trait NOTBETWEEN[T <: CriteriaTag] extends PredicateBinary[T]
 
-  implicit val gtBuilder: Builder2[GT] = new Builder2[GT] {
+  implicit val gtBuilder: BuilderBinary[GT] = new BuilderBinary[GT] {
     override def build[T <: CriteriaTag](
         F: (String, String) => String
     ): GT[T] = new GT[T] {
@@ -73,7 +73,7 @@ object PredicateBinary {
     }
   }
 
-  implicit val ltBuilder: Builder2[LT] = new Builder2[LT] {
+  implicit val ltBuilder: BuilderBinary[LT] = new BuilderBinary[LT] {
     override def build[T <: CriteriaTag](F: (String, String) => String): LT[T] = new LT[T] {
       override def eval[L, R](cr1: Ref[T, L], cr2: Ref[T, R])(implicit
           showL: Show[L, T],
@@ -82,7 +82,7 @@ object PredicateBinary {
     }
   }
 
-  implicit val eqBuilder: Builder2[EQ] = new Builder2[EQ] {
+  implicit val eqBuilder: BuilderBinary[EQ] = new BuilderBinary[EQ] {
     override def build[T <: CriteriaTag](F: (String, String) => String): EQ[T] = new EQ[T] {
       override def eval[L, R](cr1: Ref[T, L], cr2: Ref[T, R])(implicit
           showL: Show[L, T],
@@ -91,7 +91,7 @@ object PredicateBinary {
     }
   }
 
-  implicit val neqBuilder: Builder2[NEQ] = new Builder2[NEQ] {
+  implicit val neqBuilder: BuilderBinary[NEQ] = new BuilderBinary[NEQ] {
     override def build[T <: CriteriaTag](F: (String, String) => String): NEQ[T] = new NEQ[T] {
       override def eval[L, R](cr1: Ref[T, L], cr2: Ref[T, R])(implicit
           showL: Show[L, T],
@@ -100,7 +100,7 @@ object PredicateBinary {
     }
   }
 
-  implicit val geqBuilder: Builder2[GEQ] = new Builder2[GEQ] {
+  implicit val geqBuilder: BuilderBinary[GEQ] = new BuilderBinary[GEQ] {
     override def build[T <: CriteriaTag](F: (String, String) => String): GEQ[T] = new GEQ[T] {
       override def eval[L, R](cr1: Ref[T, L], cr2: Ref[T, R])(implicit
           showL: Show[L, T],
@@ -109,7 +109,7 @@ object PredicateBinary {
     }
   }
 
-  implicit val leqBuilder: Builder2[LEQ] = new Builder2[LEQ] {
+  implicit val leqBuilder: BuilderBinary[LEQ] = new BuilderBinary[LEQ] {
     override def build[T <: CriteriaTag](F: (String, String) => String): LEQ[T] = new LEQ[T] {
       override def eval[L, R](cr1: Ref[T, L], cr2: Ref[T, R])(implicit
           showL: Show[L, T],
@@ -118,7 +118,7 @@ object PredicateBinary {
     }
   }
 
-  implicit val likeBuilder: Builder2[LIKE] = new Builder2[LIKE] {
+  implicit val likeBuilder: BuilderBinary[LIKE] = new BuilderBinary[LIKE] {
     override def build[T <: CriteriaTag](F: (String, String) => String): LIKE[T] = new LIKE[T] {
       override def eval[L, R](cr1: Ref[T, L], cr2: Ref[T, R])(implicit
           showL: Show[L, T],
@@ -127,7 +127,7 @@ object PredicateBinary {
     }
   }
 
-  implicit val inBuilder: Builder2[IN] = new Builder2[IN] {
+  implicit val inBuilder: BuilderBinary[IN] = new BuilderBinary[IN] {
     override def build[T <: CriteriaTag](F: (String, String) => String): IN[T] = new IN[T] {
       override def eval[L, R](cr1: Ref[T, L], cr2: Ref[T, R])(implicit
           showL: Show[L, T],
@@ -136,7 +136,7 @@ object PredicateBinary {
     }
   }
 
-  implicit val notinBuilder: Builder2[NOTIN] = new Builder2[NOTIN] {
+  implicit val notinBuilder: BuilderBinary[NOTIN] = new BuilderBinary[NOTIN] {
     override def build[T <: CriteriaTag](F: (String, String) => String): NOTIN[T] =
       new NOTIN[T] {
         override def eval[L, R](cr1: Ref[T, L], cr2: Ref[T, R])(implicit
@@ -146,7 +146,7 @@ object PredicateBinary {
       }
   }
 
-  implicit val betweenBuilder: Builder2[BETWEEN] = new Builder2[BETWEEN] {
+  implicit val betweenBuilder: BuilderBinary[BETWEEN] = new BuilderBinary[BETWEEN] {
     override def build[T <: CriteriaTag](F: (String, String) => String): BETWEEN[T] =
       new BETWEEN[T] {
         override def eval[L, R](cr1: Ref[T, L], cr2: Ref[T, R])(implicit
@@ -156,7 +156,7 @@ object PredicateBinary {
       }
   }
 
-  implicit val notbetweenBuilder: Builder2[NOTBETWEEN] = new Builder2[NOTBETWEEN] {
+  implicit val notbetweenBuilder: BuilderBinary[NOTBETWEEN] = new BuilderBinary[NOTBETWEEN] {
     override def build[T <: CriteriaTag](F: (String, String) => String): NOTBETWEEN[T] =
       new NOTBETWEEN[T] {
         override def eval[L, R](cr1: Ref[T, L], cr2: Ref[T, R])(implicit

--- a/core/src/main/scala/io/github/rafafrdz/criteria4s/core/package.scala
+++ b/core/src/main/scala/io/github/rafafrdz/criteria4s/core/package.scala
@@ -4,9 +4,9 @@ package object core {
 
   type CriteriaTag = Criteria.CriteriaTag
 
-  type AND[T <: CriteriaTag] = ConjOp.AND[T]
+  type AND[T <: CriteriaTag] = Conjuction.AND[T]
 
-  type OR[T <: CriteriaTag] = ConjOp.OR[T]
+  type OR[T <: CriteriaTag] = Conjuction.OR[T]
 
   type GT[T <: CriteriaTag] = PredicateBinary.GT[T]
 

--- a/core/src/main/scala/io/github/rafafrdz/criteria4s/extensions/conjunctions.scala
+++ b/core/src/main/scala/io/github/rafafrdz/criteria4s/extensions/conjunctions.scala
@@ -1,9 +1,8 @@
 package io.github.rafafrdz.criteria4s.extensions
 
-import io.github.rafafrdz.criteria4s.core.Criteria
-import io.github.rafafrdz.criteria4s.core.Criteria.CriteriaTag
-import io.github.rafafrdz.criteria4s.core.ConjOp._
 import io.github.rafafrdz.criteria4s.{functions => F}
+import io.github.rafafrdz.criteria4s.core.Conjuction._
+import io.github.rafafrdz.criteria4s.core.{Criteria, CriteriaTag}
 
 trait conjunctions {
 

--- a/core/src/main/scala/io/github/rafafrdz/criteria4s/extensions/predicates.scala
+++ b/core/src/main/scala/io/github/rafafrdz/criteria4s/extensions/predicates.scala
@@ -1,11 +1,10 @@
 package io.github.rafafrdz.criteria4s.extensions
 
-import io.github.rafafrdz.criteria4s.core.Criteria.CriteriaTag
+import io.github.rafafrdz.criteria4s.{functions => F}
+import io.github.rafafrdz.criteria4s.core.{Criteria, CriteriaTag, Ref, Show}
 import io.github.rafafrdz.criteria4s.core.PredicateBinary._
 import io.github.rafafrdz.criteria4s.core.PredicateUnary._
 import io.github.rafafrdz.criteria4s.core.Ref.Collection
-import io.github.rafafrdz.criteria4s.core.{Criteria, Ref, Show}
-import io.github.rafafrdz.criteria4s.{functions => F}
 
 trait predicates {
 

--- a/core/src/main/scala/io/github/rafafrdz/criteria4s/functions/conjunctions.scala
+++ b/core/src/main/scala/io/github/rafafrdz/criteria4s/functions/conjunctions.scala
@@ -1,8 +1,7 @@
 package io.github.rafafrdz.criteria4s.functions
 
-import io.github.rafafrdz.criteria4s.core.Criteria
-import io.github.rafafrdz.criteria4s.core.Criteria.CriteriaTag
-import io.github.rafafrdz.criteria4s.core.ConjOp._
+import io.github.rafafrdz.criteria4s.core.{Criteria, CriteriaTag}
+import io.github.rafafrdz.criteria4s.core.Conjuction._
 
 private[functions] trait conjunctions {
 

--- a/core/src/main/scala/io/github/rafafrdz/criteria4s/functions/package.scala
+++ b/core/src/main/scala/io/github/rafafrdz/criteria4s/functions/package.scala
@@ -1,26 +1,24 @@
 package io.github.rafafrdz.criteria4s
 
-import io.github.rafafrdz.criteria4s.core.Criteria.CriteriaTag
 import io.github.rafafrdz.criteria4s.core._
 
 package object functions extends predicates with conjunctions {
 
-  def predBinary[T <: CriteriaTag, H <: PredicateBinary[T], L, R](cr1: Ref[T, L], cr2: Ref[T, R])(
-      implicit
+  def pred[T <: CriteriaTag, H <: PredicateBinary[T], L, R](cr1: Ref[T, L], cr2: Ref[T, R])(implicit
       H: H,
       showL: Show[L, T],
       showR: Show[R, T]
   ): Criteria[T] =
     H.eval(cr1, cr2)
 
-  def predUnary[T <: CriteriaTag, H <: PredicateUnary[T], V](ref: Ref[T, V])(implicit
+  def pred[T <: CriteriaTag, H <: PredicateUnary[T], V](ref: Ref[T, V])(implicit
       H: H,
       show: Show[V, T]
   ): Criteria[T] =
     H.eval(ref)
 
-  def cond[T <: CriteriaTag, H <: ConjOp[T]](cr1: Criteria[T], cr2: Criteria[T])(implicit
-      H: H
+  def cond[T <: CriteriaTag, H <: Conjuction[T]](cr1: Criteria[T], cr2: Criteria[T])(implicit
+                                                                                     H: H
   ): Criteria[T] =
     H.eval(cr1, cr2)
 

--- a/core/src/main/scala/io/github/rafafrdz/criteria4s/functions/predicates.scala
+++ b/core/src/main/scala/io/github/rafafrdz/criteria4s/functions/predicates.scala
@@ -1,10 +1,9 @@
 package io.github.rafafrdz.criteria4s.functions
 
-import io.github.rafafrdz.criteria4s.core.Criteria.CriteriaTag
+import io.github.rafafrdz.criteria4s.core.{Column, Criteria, CriteriaTag, Ref, Show}
 import io.github.rafafrdz.criteria4s.core.PredicateBinary._
 import io.github.rafafrdz.criteria4s.core.PredicateUnary._
-import io.github.rafafrdz.criteria4s.core.Ref.{Bool, Col, Collection, Value}
-import io.github.rafafrdz.criteria4s.core.{Column, Criteria, Ref, Show}
+import io.github.rafafrdz.criteria4s.core.Ref._
 
 private[functions] trait predicates {
 
@@ -26,69 +25,69 @@ private[functions] trait predicates {
       showL: Show[L, T],
       showR: Show[R, T]
   ): Criteria[T] =
-    predBinary[T, LT[T], L, R](cr1, cr2)
+    pred[T, LT[T], L, R](cr1, cr2)
 
   def gt[T <: CriteriaTag: GT, L, R](cr1: Ref[T, L], cr2: Ref[T, R])(implicit
       showL: Show[L, T],
       showR: Show[R, T]
   ): Criteria[T] =
-    predBinary[T, GT[T], L, R](cr1, cr2)
+    pred[T, GT[T], L, R](cr1, cr2)
 
   def ===[T <: CriteriaTag: EQ, L, R](cr1: Ref[T, L], cr2: Ref[T, R])(implicit
       showL: Show[L, T],
       showR: Show[R, T]
   ): Criteria[T] =
-    predBinary[T, EQ[T], L, R](cr1, cr2)
+    pred[T, EQ[T], L, R](cr1, cr2)
 
   def =!=[T <: CriteriaTag: NEQ, L, R](cr1: Ref[T, L], cr2: Ref[T, R])(implicit
       showL: Show[L, T],
       showR: Show[R, T]
   ): Criteria[T] =
-    predBinary[T, NEQ[T], L, R](cr1, cr2)
+    pred[T, NEQ[T], L, R](cr1, cr2)
 
   def neq[T <: CriteriaTag: NEQ, L, R](cr1: Ref[T, L], cr2: Ref[T, R])(implicit
       showL: Show[L, T],
       showR: Show[R, T]
   ): Criteria[T] =
-    predBinary[T, NEQ[T], L, R](cr1, cr2)
+    pred[T, NEQ[T], L, R](cr1, cr2)
 
   def geq[T <: CriteriaTag: GEQ, L, R](cr1: Ref[T, L], cr2: Ref[T, R])(implicit
       showL: Show[L, T],
       showR: Show[R, T]
   ): Criteria[T] =
-    predBinary[T, GEQ[T], L, R](cr1, cr2)
+    pred[T, GEQ[T], L, R](cr1, cr2)
 
   def leq[T <: CriteriaTag: LEQ, L, R](cr1: Ref[T, L], cr2: Ref[T, R])(implicit
       showL: Show[L, T],
       showR: Show[R, T]
   ): Criteria[T] =
-    predBinary[T, LEQ[T], L, R](cr1, cr2)
+    pred[T, LEQ[T], L, R](cr1, cr2)
 
   def like[T <: CriteriaTag: LIKE, L, R](cr1: Ref[T, L], cr2: Ref[T, R])(implicit
       showL: Show[L, T],
       showR: Show[R, T]
   ): Criteria[T] =
-    predBinary[T, LIKE[T], L, R](cr1, cr2)
+    pred[T, LIKE[T], L, R](cr1, cr2)
 
   def in[T <: CriteriaTag: IN, L, R](cr1: Ref[T, L], cr2: Ref[T, R])(implicit
       showL: Show[L, T],
       showR: Show[R, T]
   ): Criteria[T] =
-    predBinary[T, IN[T], L, R](cr1, cr2)
+    pred[T, IN[T], L, R](cr1, cr2)
 
   def notIn[T <: CriteriaTag: NOTIN, L, R](cr1: Ref[T, L], cr2: Ref[T, R])(implicit
       showL: Show[L, T],
       showR: Show[R, T]
   ): Criteria[T] =
-    predBinary[T, NOTIN[T], L, R](cr1, cr2)
+    pred[T, NOTIN[T], L, R](cr1, cr2)
 
   def isNull[T <: CriteriaTag: ISNULL, V](cr1: Ref[T, V])(implicit show: Show[V, T]): Criteria[T] =
-    predUnary[T, ISNULL[T], V](cr1)
+    pred[T, ISNULL[T], V](cr1)
 
   def isNotNull[T <: CriteriaTag: ISNOTNULL, V](cr1: Ref[T, V])(implicit
       show: Show[V, T]
   ): Criteria[T] =
-    predUnary[T, ISNOTNULL[T], V](cr1)
+    pred[T, ISNOTNULL[T], V](cr1)
 
   def between[T <: CriteriaTag: BETWEEN, L, R](
       cr1: Ref[T, L],
@@ -97,7 +96,7 @@ private[functions] trait predicates {
       showL: Show[L, T],
       showR: Show[R, T]
   ): Criteria[T] =
-    predBinary[T, BETWEEN[T], L, R](cr1, cr2)
+    pred[T, BETWEEN[T], L, R](cr1, cr2)
 
   def notBetween[T <: CriteriaTag: NOTBETWEEN, L, R](
       cr1: Ref[T, L],
@@ -106,7 +105,7 @@ private[functions] trait predicates {
       showL: Show[L, T],
       showR: Show[R, T]
   ): Criteria[T] =
-    predBinary[T, NOTBETWEEN[T], L, R](cr1, cr2)
+    pred[T, NOTBETWEEN[T], L, R](cr1, cr2)
 }
 
 object predicates extends predicates

--- a/core/src/main/scala/io/github/rafafrdz/criteria4s/instances/builder/BuilderBinary.scala
+++ b/core/src/main/scala/io/github/rafafrdz/criteria4s/instances/builder/BuilderBinary.scala
@@ -1,7 +1,7 @@
 package io.github.rafafrdz.criteria4s.instances.builder
 
-import io.github.rafafrdz.criteria4s.core.Criteria.CriteriaTag
+import io.github.rafafrdz.criteria4s.core.CriteriaTag
 
-trait Builder2[H[_ <: CriteriaTag]] {
+trait BuilderBinary[H[_ <: CriteriaTag]] {
   def build[T <: CriteriaTag](F: (String, String) => String): H[T]
 }

--- a/core/src/main/scala/io/github/rafafrdz/criteria4s/instances/builder/BuilderUnary.scala
+++ b/core/src/main/scala/io/github/rafafrdz/criteria4s/instances/builder/BuilderUnary.scala
@@ -1,7 +1,7 @@
 package io.github.rafafrdz.criteria4s.instances.builder
 
-import io.github.rafafrdz.criteria4s.core.Criteria.CriteriaTag
+import io.github.rafafrdz.criteria4s.core.CriteriaTag
 
-trait Builder1[H[_ <: CriteriaTag]] {
+trait BuilderUnary[H[_ <: CriteriaTag]] {
   def build[T <: CriteriaTag](F: String => String): H[T]
 }

--- a/core/src/main/scala/io/github/rafafrdz/criteria4s/instances/package.scala
+++ b/core/src/main/scala/io/github/rafafrdz/criteria4s/instances/package.scala
@@ -1,16 +1,16 @@
 package io.github.rafafrdz.criteria4s
 
-import io.github.rafafrdz.criteria4s.core.Criteria.CriteriaTag
-import io.github.rafafrdz.criteria4s.instances.builder.{Builder1, Builder2}
+import io.github.rafafrdz.criteria4s.core.CriteriaTag
+import io.github.rafafrdz.criteria4s.instances.builder.{BuilderBinary, BuilderUnary}
 
 package object instances {
   def build[T <: CriteriaTag, H[_ <: CriteriaTag]](F: (String, String) => String)(implicit
-      BH: Builder2[H]
+      BH: BuilderBinary[H]
   ): H[T] =
     BH.build(F)
 
-  def build1[T <: CriteriaTag, H[_ <: CriteriaTag]](F: String => String)(implicit
-      BH: Builder1[H]
+  def build[T <: CriteriaTag, H[_ <: CriteriaTag]](F: String => String)(implicit
+      BH: BuilderUnary[H]
   ): H[T] =
     BH.build(F)
 }

--- a/examples/src/main/scala/io/github/rafafrdz/criteria4s/examples/datastores/WeirdDatastore.scala
+++ b/examples/src/main/scala/io/github/rafafrdz/criteria4s/examples/datastores/WeirdDatastore.scala
@@ -1,20 +1,19 @@
 package io.github.rafafrdz.criteria4s.examples.datastores
 
-import io.github.rafafrdz.criteria4s.core.ConjOp._
-import io.github.rafafrdz.criteria4s.core.Criteria.CriteriaTag
+import io.github.rafafrdz.criteria4s.core.Conjuction._
+import io.github.rafafrdz.criteria4s.core.{Column, CriteriaTag, Show}
 import io.github.rafafrdz.criteria4s.core.PredicateBinary._
 import io.github.rafafrdz.criteria4s.core.PredicateUnary._
-import io.github.rafafrdz.criteria4s.core.{Column, Show}
 import io.github.rafafrdz.criteria4s.instances._
 
 trait WeirdDatastore extends CriteriaTag
 
 object WeirdDatastore {
 
-  private def wope(symbol: String)(left: String, right: String): String =
+  private def wope(symbol: String): (String, String) => String = (left: String, right: String) =>
     s"""{left: $left, opt: $symbol, right: $right }""".stripMargin
 
-  private def wope1(symbol: String)(left: String): String =
+  private def wope1(symbol: String): String => String = (left: String) =>
     s"""{left: $left, opt: $symbol }""".stripMargin
 
   implicit def showSeq[V](implicit show: Show[V, WeirdDatastore]): Show[Seq[V], WeirdDatastore] =
@@ -47,10 +46,10 @@ object WeirdDatastore {
 
   implicit val notinPred: NOTIN[WeirdDatastore] = build[WeirdDatastore, NOTIN](wope("NOT IN"))
 
-  implicit val isnullPred: ISNULL[WeirdDatastore] = build1[WeirdDatastore, ISNULL](wope1("IS NULL"))
+  implicit val isnullPred: ISNULL[WeirdDatastore] = build[WeirdDatastore, ISNULL](wope1("IS NULL"))
 
   implicit val isnotnullPred: ISNOTNULL[WeirdDatastore] =
-    build1[WeirdDatastore, ISNOTNULL](wope1("IS NOT NULL"))
+    build[WeirdDatastore, ISNOTNULL](wope1("IS NOT NULL"))
 
   implicit val betweenPred: BETWEEN[WeirdDatastore] =
     build[WeirdDatastore, BETWEEN](wope("BETWEEN"))


### PR DESCRIPTION
In this PR:

- We unify both `build1` and `build` method to an unique `build` method
- We unify both `predBinary` and `predUnary` method to an unique `pred` method. One could distinguish which is which by knowing its constructor. If the constructor has one gap, then it is `unary`, if it has two then it is `binary`.
- We rename `Builder1` and `Builder2` into `BuilderUnary` and `BuilderBinary`.
- We rename `ConjOp` into `Conjuction`
- We privatize `CriteriaTag` from `Criteria` companion object. Thanks to that you could import `CriteriaTag` by typing `import io.github.rafafrdz.criteria4s.core._` instead of `import io.github.rafafrdz.criteria4s.core.Criteria._` and also we obtain just one way to import it.
- We apply these changes to the SQL interpreter and the `WeirdDatastore` interpreter implementation.
- We rearrange the imports in some files 