### PR TITLE
Dialect package

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,16 @@ libraryDependencies += "io.github.rafafrdz" %% "criteria4s-sql" % "<version>" //
 > [!IMPORTANT]  
 > Criteria4s is a work in progress and it is not ready for production use. Also, it is just available for Scala 2.13.
 
+## Dialects
+
+Criteria4s is extensible to support any kind of data stores. Currently, it supports the following **dialects**:
+
+| Dialect     | Package                                                                                    | Example |
+|-------------|:-------------------------------------------------------------------------------------------|:--------|
+| SQL         | [sql](./sql/src/main/scala/io/github/rafafrdz/criteria4s/dialect/sql)                      | -       |
+| MongoDB     | [mongodb](./mongodb/src/main/scala/io/github/rafafrdz/criteria4s/dialect/mongodb)          | -       |
+| PostgresSQL | [postgresql](./postgresql/src/main/scala/io/github/rafafrdz/criteria4s/dialect/postgresql) | -       |
+
 ## Examples
 
 Here, we will show some examples of how to use the Criteria DSL.

--- a/examples/src/main/scala/io/github/rafafrdz/criteria4s/examples/datastores/MySQL.scala
+++ b/examples/src/main/scala/io/github/rafafrdz/criteria4s/examples/datastores/MySQL.scala
@@ -3,7 +3,7 @@ package io.github.rafafrdz.criteria4s.examples.datastores
 import io.github.rafafrdz.criteria4s.core.PredicateBinary._
 import io.github.rafafrdz.criteria4s.core.{Column, Show}
 import io.github.rafafrdz.criteria4s.instances._
-import io.github.rafafrdz.criteria4s.sql._
+import io.github.rafafrdz.criteria4s.dialect.sql._
 
 trait MySQL extends SQL
 

--- a/examples/src/main/scala/io/github/rafafrdz/criteria4s/examples/datastores/Postgres.scala
+++ b/examples/src/main/scala/io/github/rafafrdz/criteria4s/examples/datastores/Postgres.scala
@@ -1,7 +1,7 @@
 package io.github.rafafrdz.criteria4s.examples.datastores
 
 import io.github.rafafrdz.criteria4s.core.{Column, Show}
-import io.github.rafafrdz.criteria4s.sql.{SQL, _}
+import io.github.rafafrdz.criteria4s.dialect.sql.{SQL, _}
 
 trait Postgres  extends SQL
 object Postgres extends SQLExpr[Postgres] {

--- a/sql/src/main/scala/io/github/rafafrdz/criteria4s/dialect/sql/SQL.scala
+++ b/sql/src/main/scala/io/github/rafafrdz/criteria4s/dialect/sql/SQL.scala
@@ -1,4 +1,4 @@
-package io.github.rafafrdz.criteria4s.sql
+package io.github.rafafrdz.criteria4s.dialect.sql
 
 import io.github.rafafrdz.criteria4s.core.Conjuction._
 import io.github.rafafrdz.criteria4s.core.PredicateBinary._

--- a/sql/src/main/scala/io/github/rafafrdz/criteria4s/dialect/sql/package.scala
+++ b/sql/src/main/scala/io/github/rafafrdz/criteria4s/dialect/sql/package.scala
@@ -1,4 +1,4 @@
-package io.github.rafafrdz.criteria4s
+package io.github.rafafrdz.criteria4s.dialect
 
 package object sql extends SQL.SQLExpr[SQL] {
 


### PR DESCRIPTION
In this PR we move the dialect SQL to a new package-level `dialect` in order to get it better organized. Also we include a list of the current and future dialects that we are going to provide in criteria4s in the README.