### PR TITLE
fix: add default Show[Seq] and Show[Tuple] instances to SQL dialect

### DIFF
--- a/sql/src/main/scala/com/eff3ct/criteria4s/dialect/sql/SQL.scala
+++ b/sql/src/main/scala/com/eff3ct/criteria4s/dialect/sql/SQL.scala
@@ -46,6 +46,12 @@ object SQL {
   implicit val showColumn: Show[Column, SQL] =
     Show.create(col => s"'${col.colName}'")
 
+  implicit def showSeq[V](implicit show: Show[V, SQL]): Show[Seq[V], SQL] =
+    Show.create(_.map(show.show).mkString("(", ", ", ")"))
+
+  implicit def showTuple[V](implicit show: Show[V, SQL]): Show[(V, V), SQL] =
+    Show.create { case (l, r) => s"${show.show(l)} AND ${show.show(r)}" }
+
   trait SQLExpr[T <: SQL] {
 
     protected def conjExpr(symbol: String): (String, String) => String =


### PR DESCRIPTION
## Summary
- Add `Show[Seq[V], SQL]` → renders as `(v1, v2, v3)` 
- Add `Show[(V, V), SQL]` → renders as `v1 AND v2` (standard SQL BETWEEN syntax)
- `IN`, `NOTIN`, `BETWEEN`, `NOTBETWEEN` now work out of the box without subclassing

Closes #2