### PR TITLE
feat: add eqv() word alias for === predicate

### DIFF
--- a/core/src/main/scala/com/eff3ct/criteria4s/extensions/predicates.scala
+++ b/core/src/main/scala/com/eff3ct/criteria4s/extensions/predicates.scala
@@ -51,6 +51,10 @@ trait predicates {
         other: Ref[T, R]
     )(implicit H: EQ[T], showL: Show[L, T], showR: Show[R, T]): Criteria[T] = F.===(c, other)
 
+    def eqv[R](
+        other: Ref[T, R]
+    )(implicit H: EQ[T], showL: Show[L, T], showR: Show[R, T]): Criteria[T] = F.===(c, other)
+
     def =!=[R](
         other: Ref[T, R]
     )(implicit H: NEQ[T], showL: Show[L, T], showR: Show[R, T]): Criteria[T] = F.=!=(c, other)

--- a/core/src/main/scala/com/eff3ct/criteria4s/functions/predicates.scala
+++ b/core/src/main/scala/com/eff3ct/criteria4s/functions/predicates.scala
@@ -63,6 +63,12 @@ private[functions] trait predicates {
   ): Criteria[T] =
     pred[T, EQ[T], L, R](cr1, cr2)
 
+  def eqv[T <: CriteriaTag: EQ, L, R](cr1: Ref[T, L], cr2: Ref[T, R])(implicit
+      showL: Show[L, T],
+      showR: Show[R, T]
+  ): Criteria[T] =
+    pred[T, EQ[T], L, R](cr1, cr2)
+
   def =!=[T <: CriteriaTag: NEQ, L, R](cr1: Ref[T, L], cr2: Ref[T, R])(implicit
       showL: Show[L, T],
       showR: Show[R, T]


### PR DESCRIPTION
## Summary
- Add `eqv()` function alias for `===` in `functions/predicates.scala`
- Add `.eqv()` extension method in `extensions/predicates.scala`
- Named `eqv` (equal value) instead of `eq` to avoid shadowing `AnyRef.eq`
- Mirrors how `neq()` aliases `=!=()`

Closes #4